### PR TITLE
Set same-origin as default

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,10 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
   remoteInput.dispatchEvent(new CustomEvent('loadstart'))
   remoteInput.setAttribute('loading', '')
   try {
-    const response = await fetch(url, {headers: {accept: 'text/html; fragment'}})
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: {accept: 'text/html; fragment'}
+    })
     const html = await response.text()
     remoteInput.dispatchEvent(new CustomEvent('load'))
     resultsContainer.innerHTML = html


### PR DESCRIPTION
Got some 404 reports from old Chrome and Safari.

ref: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials#Browser_compatibility
