### PR TITLE
Handle not successful responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,12 @@ remote-input[loading] .loading-icon { display: inline; }
 
 ### Events
 
-```js
-const remoteInput = document.querySelector('remote-input')
-
-// Network request lifecycle events.
-remoteInput.addEventListener('loadstart', function(event) {
-  console.log('Network request started', event)
-})
-remoteInput.addEventListener('loadend', function(event) {
-  console.log('Network request complete', event)
-})
-remoteInput.addEventListener('load', function(event) {
-  console.log('Network request succeeded', event)
-})
-remoteInput.addEventListener('error', function(event) {
-  console.log('Network request failed', event)
-})
-```
+- `loadstart` - The server fetch has started.
+- `load` - The network request completed successfully.
+- `error` - The network request failed.
+- `loadend` - The network request has completed.
+- `remote-input-success` – Received a successful response (status code 200-299). Bubbles.
+- `remote-input-error` – Received a not successful response. Bubbles.
 
 ## Browser support
 

--- a/index.js
+++ b/index.js
@@ -70,17 +70,23 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
 
   remoteInput.dispatchEvent(new CustomEvent('loadstart'))
   remoteInput.setAttribute('loading', '')
+  let response, html
   try {
-    const response = await fetch(url, {
+    response = await fetch(url, {
       credentials: 'same-origin',
       headers: {accept: 'text/html; fragment'}
     })
-    const html = await response.text()
+    html = await response.text()
     remoteInput.dispatchEvent(new CustomEvent('load'))
-    resultsContainer.innerHTML = html
   } catch {
+    // noop
+  }
+  if (response && response.ok && html) {
+    resultsContainer.innerHTML = html
+  } else {
     remoteInput.dispatchEvent(new CustomEvent('error'))
   }
+
   remoteInput.removeAttribute('loading')
   remoteInput.dispatchEvent(new CustomEvent('loadend'))
 }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
 
   remoteInput.dispatchEvent(new CustomEvent('loadstart'))
   remoteInput.setAttribute('loading', '')
-  let response, html
+  let response
+  let html = ''
   try {
     response = await fetch(url, {
       credentials: 'same-origin',
@@ -79,9 +80,9 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
     html = await response.text()
     remoteInput.dispatchEvent(new CustomEvent('load'))
   } catch {
-    // noop
+    // Network errors handled below.
   }
-  if (response && response.ok && html) {
+  if (response && response.ok) {
     resultsContainer.innerHTML = html
   } else {
     remoteInput.dispatchEvent(new CustomEvent('error'))

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
   remoteInput.dispatchEvent(new CustomEvent('loadstart'))
   remoteInput.setAttribute('loading', '')
   let response
+  let errored = false
   let html = ''
   try {
     response = await fetch(url, {
@@ -80,15 +81,19 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
     html = await response.text()
     remoteInput.dispatchEvent(new CustomEvent('load'))
   } catch {
-    // Network errors handled below.
-  }
-  if (response && response.ok) {
-    resultsContainer.innerHTML = html
-  } else {
+    errored = true
     remoteInput.dispatchEvent(new CustomEvent('error'))
   }
-
   remoteInput.removeAttribute('loading')
+  if (errored) return
+
+  if (response && response.ok) {
+    remoteInput.dispatchEvent(new CustomEvent('remote-input-success', {bubbles: true}))
+    resultsContainer.innerHTML = html
+  } else {
+    remoteInput.dispatchEvent(new CustomEvent('remote-input-error', {bubbles: true}))
+  }
+
   remoteInput.dispatchEvent(new CustomEvent('loadend'))
 }
 

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,15 +1,23 @@
 function reply(request, response, next) {
   if (request.method === 'GET') {
-    const status = request.url.startsWith('/500') ? 500 : 200
-    response.writeHead(status)
-    response.ok = status === 200
-    response.end(`
-      <ol data-src="${request.url}">
-        <li>item</li>
-        <li>item</li>
-        <li>item</li>
-      </ol>
-    `)
+    if (request.url.startsWith('/500')) {
+      response.writeHead(500)
+      response.ok = false
+      response.end('Server error')
+    } else if (request.url.startsWith('/network-error')) {
+      request.destroy(new Error())
+      response.end()
+    } else {
+      response.writeHead(200)
+      response.ok = true
+      response.end(`
+        <ol data-src="${request.url}">
+          <li>item</li>
+          <li>item</li>
+          <li>item</li>
+        </ol>
+      `)
+    }
     return
   }
   next()

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,6 +1,8 @@
 function reply(request, response, next) {
   if (request.method === 'GET') {
-    response.writeHead(200)
+    const status = request.url.startsWith('/500') ? 500 : 200
+    response.writeHead(status)
+    response.ok = status === 200
     response.end(`
       <ol data-src="${request.url}">
         <li>item</li>

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,25 @@ describe('remote-input', function() {
       input.focus()
     })
 
+    it('handles not ok responses', function(done) {
+      const remoteInput = document.querySelector('remote-input')
+      const input = document.querySelector('input')
+      const results = document.querySelector('#results')
+      remoteInput.src = '/500'
+      assert.equal(results.innerHTML, '')
+      let errorHappened = false
+      remoteInput.addEventListener('error', function() {
+        errorHappened = true
+      })
+      remoteInput.addEventListener('loadend', function() {
+        assert.ok(errorHappened, 'error event happened')
+        assert.equal(results.innerHTML, '', 'nothing was appended')
+        done()
+      })
+      input.value = 'test'
+      input.focus()
+    })
+
     it('repects param attribute', function(done) {
       const remoteInput = document.querySelector('remote-input')
       const input = document.querySelector('input')

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,12 @@ describe('remote-input', function() {
       const input = document.querySelector('input')
       const results = document.querySelector('#results')
       assert.equal(results.innerHTML, '')
+      let successEvent = false
+      remoteInput.addEventListener('remote-input-success', function() {
+        successEvent = true
+      })
       remoteInput.addEventListener('loadend', function() {
+        assert.ok(successEvent, 'success event happened')
         assert.equal(results.querySelector('ol').getAttribute('data-src'), '/results?q=test')
         done()
       })
@@ -44,17 +49,34 @@ describe('remote-input', function() {
       const results = document.querySelector('#results')
       remoteInput.src = '/500'
       assert.equal(results.innerHTML, '')
-      let errorHappened = false
-      remoteInput.addEventListener('error', function() {
-        errorHappened = true
+      let errorEvent = false
+      remoteInput.addEventListener('remote-input-error', function() {
+        errorEvent = true
       })
       remoteInput.addEventListener('loadend', function() {
-        assert.ok(errorHappened, 'error event happened')
+        assert.ok(errorEvent, 'error event happened')
         assert.equal(results.innerHTML, '', 'nothing was appended')
         done()
       })
       input.value = 'test'
       input.focus()
+    })
+
+    it('handles network error', function(done) {
+      const remoteInput = document.querySelector('remote-input')
+      const input = document.querySelector('input')
+      const results = document.querySelector('#results')
+      remoteInput.src = '/network-error'
+      assert.equal(results.innerHTML, '')
+      remoteInput.addEventListener('error', async function() {
+        await Promise.resolve()
+        assert.equal(results.innerHTML, '', 'nothing was appended')
+        assert.notOk(remoteInput.hasAttribute('loading'), 'loading attribute was removed')
+        done()
+      })
+      input.value = 'test'
+      input.focus()
+      assert.ok(remoteInput.hasAttribute('loading'), 'loading attribute was added')
     })
 
     it('repects param attribute', function(done) {


### PR DESCRIPTION
Fixes #10. 

When response status is not successful (200-299), emits an error event and don't set HTML.

cc @arielvalentin 