### PR TITLE
Add TS window declaration for RemoteInputElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,6 @@ export default class RemoteInputElement extends HTMLElement {
 
 declare global {
   interface Window {
-    RemoteInputElement: RemoteInputElement
+    RemoteInputElement: typeof RemoteInputElement
   }
 }


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `RemoteInputElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58