### PR TITLE
Abort in-flight requests

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -42,6 +42,6 @@
   <!-- <script type="module" src="../dist/index.js"></script> -->
 
   <!-- GitHub Pages demo script -->
-  <script src="https://unpkg.com/@github/remote-input-element@latest/dist/index.umd.js"></script>
+  <script type="module" src="https://unpkg.com/@github/remote-input-element@latest/dist/index.js"></script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -39,7 +39,7 @@
   <ul id="results"></ul>
 
   <!-- GitHub Pages development script, uncomment when running example locally and comment out the production one -->
-  <!-- <script src="../dist/index.umd.js"></script> -->
+  <!-- <script type="module" src="../dist/index.js"></script> -->
 
   <!-- GitHub Pages demo script -->
   <script src="https://unpkg.com/@github/remote-input-element@latest/dist/index.umd.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,16 +11,16 @@
     function fakeFetch(url) {
       const urlObj = new URL(url)
       let html = ''
-      if (url.pathname === '/results') {
+      if (urlObj.pathname === '/results') {
         const doc = document.createElement('div')
         doc.innerHTML = `<li>Hubot</li><li>BB-8</li><li>Wall-E</li><li>Bender</li>`
-        const q = url.searchParams.get('q')
+        const q = urlObj.searchParams.get('q')
         for (const el of doc.querySelectorAll('li')) {
           if (q !== '' && !el.textContent.toLowerCase().match(q.toLowerCase())) el.remove()
         }
         html = doc.innerHTML
-      } else if (url.pathname === '/marquee') {
-        html = `<marquee>${url.searchParams.get('q') || '🐈 Nothing to preview 🐈'}</marquee>`
+      } else if (urlObj.pathname === '/marquee') {
+        html = `<marquee>${urlObj.searchParams.get('q') || '🐈 Nothing to preview 🐈'}</marquee>`
       }
       const promiseHTML = new Promise(resolve => resolve(html))
       return new Promise(resolve => resolve({ok: true, text: () => promiseHTML}))

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,8 +22,7 @@
       } else if (urlObj.pathname === '/marquee') {
         html = `<marquee>${urlObj.searchParams.get('q') || '🐈 Nothing to preview 🐈'}</marquee>`
       }
-      const promiseHTML = new Promise(resolve => resolve(html))
-      return new Promise(resolve => resolve({ok: true, text: () => promiseHTML}))
+      return Promise.resolve({ok: true, text: () => Promise.resolve(html)})
     }
     window.fetch = fakeFetch
   </script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,11 +93,11 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
     state.controller.abort()
   } else {
     remoteInput.dispatchEvent(new CustomEvent('loadstart'))
+    remoteInput.setAttribute('loading', '')
   }
 
   state.controller = makeAbortController()
 
-  remoteInput.setAttribute('loading', '')
   let response
   let html = ''
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,9 +108,11 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
     })
     html = await response.text()
     remoteInput.removeAttribute('loading')
+    state.controller = null
   } catch (error) {
     if (error.name !== 'AbortError') {
       remoteInput.removeAttribute('loading')
+      state.controller = null
     }
     return
   }

--- a/test/test.js
+++ b/test/test.js
@@ -48,8 +48,7 @@ describe('remote-input', function() {
         once(remoteInput, 'load'),
         once(remoteInput, 'loadend')
       ])
-      input.value = 'test'
-      input.focus()
+      changeValue(input, 'test')
       await completed
 
       assert.deepEqual(['loadstart', 'load', 'loadend'], events)
@@ -61,8 +60,7 @@ describe('remote-input', function() {
       const success = once(remoteInput, 'remote-input-success')
       const loadend = once(remoteInput, 'loadend')
 
-      input.value = 'test'
-      input.focus()
+      changeValue(input, 'test')
 
       await success
       await loadend
@@ -76,8 +74,7 @@ describe('remote-input', function() {
       const error = once(remoteInput, 'remote-input-error')
       const loadend = once(remoteInput, 'loadend')
 
-      input.value = 'test'
-      input.focus()
+      changeValue(input, 'test')
 
       await loadend
       await error
@@ -91,8 +88,7 @@ describe('remote-input', function() {
 
       const result = once(remoteInput, 'error')
 
-      input.value = 'test'
-      input.focus()
+      changeValue(input, 'test')
       assert.ok(remoteInput.hasAttribute('loading'), 'loading attribute should have been added')
 
       await result
@@ -107,8 +103,7 @@ describe('remote-input', function() {
 
       const result = once(remoteInput, 'remote-input-success')
 
-      input.value = 'test'
-      input.focus()
+      changeValue(input, 'test')
 
       await result
       assert.equal(results.querySelector('ol').getAttribute('data-src'), '/results?robot=test')
@@ -116,8 +111,7 @@ describe('remote-input', function() {
 
     it('loads content again after src is changed', async function() {
       const result1 = once(remoteInput, 'remote-input-success')
-      input.value = 'test'
-      input.focus()
+      changeValue(input, 'test')
 
       await result1
       assert.equal(results.querySelector('ol').getAttribute('data-src'), '/results?q=test')
@@ -130,6 +124,11 @@ describe('remote-input', function() {
     })
   })
 })
+
+function changeValue(input, value) {
+  input.value = value
+  input.dispatchEvent(new Event('change'))
+}
 
 function nextTick() {
   return Promise.resolve()

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,10 @@ describe('remote-input', function() {
   })
 
   describe('after tree insertion', function() {
+    let remoteInput
+    let input
+    let results
+
     beforeEach(function() {
       document.body.innerHTML = `
         <remote-input aria-owns="results" src="/results">
@@ -19,16 +23,19 @@ describe('remote-input', function() {
         </remote-input>
         <div id="results"></div>
       `
+      remoteInput = document.querySelector('remote-input')
+      input = remoteInput.querySelector('input')
+      results = document.querySelector('#results')
     })
 
     afterEach(function() {
       document.body.innerHTML = ''
+      remoteInput = null
+      input = null
+      results = null
     })
 
     it('emits network events in order', async function() {
-      const remoteInput = document.querySelector('remote-input')
-      const input = document.querySelector('input')
-
       const events = []
       const track = event => events.push(event.type)
 
@@ -49,9 +56,6 @@ describe('remote-input', function() {
     })
 
     it('loads content', async function() {
-      const remoteInput = document.querySelector('remote-input')
-      const input = document.querySelector('input')
-      const results = document.querySelector('#results')
       assert.equal(results.innerHTML, '')
 
       const success = once(remoteInput, 'remote-input-success')
@@ -66,9 +70,6 @@ describe('remote-input', function() {
     })
 
     it('handles not ok responses', async function() {
-      const remoteInput = document.querySelector('remote-input')
-      const input = document.querySelector('input')
-      const results = document.querySelector('#results')
       remoteInput.src = '/500'
       assert.equal(results.innerHTML, '')
 
@@ -85,9 +86,6 @@ describe('remote-input', function() {
     })
 
     it('handles network error', async function() {
-      const remoteInput = document.querySelector('remote-input')
-      const input = remoteInput.querySelector('input')
-      const results = document.querySelector('#results')
       remoteInput.src = '/network-error'
       assert.equal(results.innerHTML, '')
 
@@ -104,9 +102,6 @@ describe('remote-input', function() {
     })
 
     it('repects param attribute', async function() {
-      const remoteInput = document.querySelector('remote-input')
-      const input = document.querySelector('input')
-      const results = document.querySelector('#results')
       remoteInput.setAttribute('param', 'robot')
       assert.equal(results.innerHTML, '')
 
@@ -120,10 +115,6 @@ describe('remote-input', function() {
     })
 
     it('loads content again after src is changed', async function() {
-      const remoteInput = document.querySelector('remote-input')
-      const input = document.querySelector('input')
-      const results = document.querySelector('#results')
-
       const result1 = once(remoteInput, 'remote-input-success')
       input.value = 'test'
       input.focus()

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,29 @@ describe('remote-input', function() {
       document.body.innerHTML = ''
     })
 
+    it('emits network events in order', async function() {
+      const remoteInput = document.querySelector('remote-input')
+      const input = document.querySelector('input')
+
+      const events = []
+      const track = event => events.push(event.type)
+
+      remoteInput.addEventListener('loadstart', track)
+      remoteInput.addEventListener('load', track)
+      remoteInput.addEventListener('loadend', track)
+
+      const completed = Promise.all([
+        once(remoteInput, 'loadstart'),
+        once(remoteInput, 'load'),
+        once(remoteInput, 'loadend')
+      ])
+      input.value = 'test'
+      input.focus()
+      await completed
+
+      assert.deepEqual(['loadstart', 'load', 'loadend'], events)
+    })
+
     it('loads content', async function() {
       const remoteInput = document.querySelector('remote-input')
       const input = document.querySelector('input')


### PR DESCRIPTION
Announce a single set of logical network events—loadstart, load, loadend—while aborting all but the final request as an internal optimization.

Closes #14