### PR TITLE
Add note about loadend -> remote-input-success

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ remote-input[loading] .loading-icon { display: inline; }
 - `error` - The network request failed.
 - `loadend` - The network request has completed.
   - Note: You should not use this event if you need to change something based on the HTML in the response as the DOM will not be updated at this point. Use `remote-input-success` instead. 
-- `remote-input-success` – Received a successful response (status code 200-299). Bubbles.
+ - `remote-input-success` – Received a successful response (status code 200-299), and response HTML has been set. Bubbles.
 - `remote-input-error` – Received a not successful response. Bubbles.
 
 ## Browser support

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ remote-input[loading] .loading-icon { display: inline; }
 - `load` - The network request completed successfully.
 - `error` - The network request failed.
 - `loadend` - The network request has completed.
+  - Note: You should not use this event if you need to change something based on the HTML in the response as the DOM will not be updated at this point. Use `remote-input-success` instead. 
 - `remote-input-success` – Received a successful response (status code 200-299). Bubbles.
 - `remote-input-error` – Received a not successful response. Bubbles.
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ remote-input[loading] .loading-icon { display: inline; }
 - `load` - The network request completed successfully.
 - `error` - The network request failed.
 - `loadend` - The network request has completed.
-  - Note: You should not use this event if you need to change something based on the HTML in the response as the DOM will not be updated at this point. Use `remote-input-success` instead. 
- - `remote-input-success` – Received a successful response (status code 200-299), and response HTML has been set. Bubbles.
+- `remote-input-success` – Received a successful response (status code 200-299), and response HTML has been set. Bubbles.
 - `remote-input-error` – Received a not successful response. Bubbles.
 
 ## Browser support


### PR DESCRIPTION
I've had 2 instances now where `loadend` is used to change HTML based on the response from `remote-input-element`.

This doesn't work properly because the DOM is not updated with the response until just after `remote-input-success`.

To avoid this issue in the future, this adds a simple note explaining this caveat

cc @github/web-systems 