### PR TITLE
Add support for network error UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ The parameter name (`q`) is customizable with the `[param]` attribute:
 <div id="md-preview"></div>
 ```
 
+### Styling error state
+
+The error UI is customizable with the `[error]` attribute:
+
+
+```html
+<!-- Live preview of Markdown -->
+<remote-input src="/preview" aria-owns="md-preview" error="<div>Whoops</div>">
+  <textarea></textarea>
+</remote-input>
+<div id="md-preview"></div>
+```
+
 ### Styling loading state
 
 A boolean `[loading]` attribute is added to `<remote-input>` when a network request begins and removed when it ends.

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,10 +117,13 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
     return
   }
 
+  let errorHtml
   if (response && response.ok) {
     resultsContainer.innerHTML = html
     remoteInput.dispatchEvent(new CustomEvent('remote-input-success', {bubbles: true}))
   } else {
+    errorHtml = remoteInput.getAttribute('error')
+    if (errorHtml !== null) resultsContainer.innerHTML = errorHtml
     remoteInput.dispatchEvent(new CustomEvent('remote-input-error', {bubbles: true}))
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -97,7 +97,7 @@ describe('remote-input', function() {
       assert.notOk(remoteInput.hasAttribute('loading'), 'loading attribute should have been removed')
     })
 
-    it('repects param attribute', async function() {
+    it('respects param attribute', async function() {
       remoteInput.setAttribute('param', 'robot')
       assert.equal(results.innerHTML, '')
 
@@ -107,6 +107,22 @@ describe('remote-input', function() {
 
       await result
       assert.equal(results.querySelector('ol').getAttribute('data-src'), '/results?robot=test')
+    })
+
+    it('respects error attribute', async function() {
+      remoteInput.src = '/500'
+      remoteInput.setAttribute('error', '<div>whoops</div>')
+      assert.equal(results.innerHTML, '')
+
+      const error = once(remoteInput, 'remote-input-error')
+      const loadend = once(remoteInput, 'loadend')
+
+      changeValue(input, 'test')
+
+      await loadend
+      await error
+
+      assert.equal(results.innerHTML, '<div>whoops</div>', 'error was appended')
     })
 
     it('loads content again after src is changed', async function() {


### PR DESCRIPTION
This change adds an optional parameter to let the user define an error UI. There are existing events the user could hook into but using a parameter seems like an easier path for a developer to support the error state.

I am very open to feedback. Thank you!