### PR TITLE
Add `text/fragment+html` to accept header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ async function fetchResults(remoteInput: RemoteInputElement, checkCurrentQuery: 
     response = await fetchWithNetworkEvents(remoteInput, url.toString(), {
       signal: state.controller.signal,
       credentials: 'same-origin',
-      headers: {accept: 'text/html; fragment'}
+      headers: {accept: 'text/html; fragment, text/fragment+html'}
     })
     html = await response.text()
     remoteInput.removeAttribute('loading')


### PR DESCRIPTION
Turns out that `text/html; fragment` isn't a valid mimetype which causes some issues with gzip compression in nginx. Changing it to use the extension `fragment` in the `text/html` mimetype should correct this oversight.

This PR adds the `text/fragment+html` mimetype to the accept header rather than straight replacing it so we can migrate github.com without downtime.